### PR TITLE
Added error handling for zero guests and past date 

### DIFF
--- a/Gotlandsrussen/Repositories/BookingRepository.cs
+++ b/Gotlandsrussen/Repositories/BookingRepository.cs
@@ -80,6 +80,9 @@ namespace Gotlandsrussen.Repositories
             if (updatedBooking.NumberOfAdults + updatedBooking.NumberOfChildren == 0)
                 throw new InvalidOperationException("Bokningen måste innehålla minst en person.");
 
+            if (updatedBooking.FromDate < DateOnly.FromDateTime(DateTime.Today))
+                throw new InvalidOperationException("Startdatumet har redan passerat.");
+
             var roomIds = booking.BookingRooms.Select(br => br.RoomId).ToList();
 
             bool hasConflict = await _context.BookingRooms


### PR DESCRIPTION
- Can not update a booking to 0 guests
- Can not update the start date to a date that has already passed